### PR TITLE
Allow specified associations to be preloaded when retrieving collection

### DIFF
--- a/app/controllers/concerns/nunchaku/resources.rb
+++ b/app/controllers/concerns/nunchaku/resources.rb
@@ -21,7 +21,7 @@ module Nunchaku
     protected
 
     def collection
-      treed_index? ? super.roots : super
+      treed_index? ? super.roots : super.preload(preloaded_associations)
     end
 
     def treed_index?
@@ -44,6 +44,10 @@ module Nunchaku
 
     def resource_params_id(resource_name)
       params["#{resource_name.classify.demodulize.underscore}_id"]
+    end
+
+    def preloaded_associations
+      nil
     end
   end
 end

--- a/app/models/concerns/nunchaku/cacheable.rb
+++ b/app/models/concerns/nunchaku/cacheable.rb
@@ -10,7 +10,7 @@ module Nunchaku
       protected
 
       def user_cache_key_fragment(user)
-        "user#{user.id}_organisation#{user.current_access_organisation.id}"
+        "user#{user.id}_organisation#{user.current_access_organisation.try(:id)}"
       end
     end
   end


### PR DESCRIPTION
Would like to hear some feedback on whether this is going to be bad or not. I know it gets rid of N+1s for the places I'm using it so far (Access screens)