### PR TITLE
Update because it will be deprecated in next simpleform

### DIFF
--- a/app/inputs/autocomplete_input.rb
+++ b/app/inputs/autocomplete_input.rb
@@ -1,6 +1,6 @@
 class AutocompleteInput < ::SimpleForm::Inputs::StringInput
 
-  def input
+  def input(*args)
     super << javascript
   end
 

--- a/app/inputs/date_picker_input.rb
+++ b/app/inputs/date_picker_input.rb
@@ -1,10 +1,10 @@
 class DatePickerInput < SimpleForm::Inputs::DateTimeInput
-  def input
+  def input(*args)
     text_field << date_select << javascript
   end
 
   def input_html_options
-    super.tap do |h| 
+    super.tap do |h|
       (h[:data] ||= {}).merge!(:handle => handle)
       h[:class] = (h[:class] || '') << ' search_query form-control'
     end

--- a/app/inputs/enhanced_select_input.rb
+++ b/app/inputs/enhanced_select_input.rb
@@ -1,5 +1,5 @@
 class EnhancedSelectInput < ::SimpleForm::Inputs::CollectionSelectInput
-  def input
+  def input(*args)
     collection_field << javascript
   end
 


### PR DESCRIPTION
Input method now accepts a `wrapper_options` argument. The method defini...tion without the argument is deprecated and will be removed in the next Simple Form version.