### PR TITLE
Don't re-declare PDF mime type. Rails does this by default

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,3 +1,2 @@
-Mime::Type.register "application/pdf", :pdf
 Mime::Type.register "application/select", :select
 Mime::Type.register "application/tree", :tree


### PR DESCRIPTION
Eliminates some noise when running things on the command line e.g.:

```
/Users/bencaldwell/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/actionpack-4.1.8/lib/action_dispatch/http/mime_type.rb:163: warning: already initialized constant Mime::PDF
/Users/bencaldwell/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/actionpack-4.1.8/lib/action_dispatch/http/mime_type.rb:163: warning: previous definition of PDF was here
```