### PR TITLE
Use rails' simple_format method, to break up the...

### DIFF
--- a/app/helpers/nunchaku/documentation_header_helper.rb
+++ b/app/helpers/nunchaku/documentation_header_helper.rb
@@ -4,7 +4,7 @@ module Nunchaku
     protected
 
     def documentation(section)
-      r = t("api_documentation.#{params[:controller]}#{params[:type]}.#{section}")
+      r = simple_format(t("api_documentation.#{params[:controller]}.#{section}"))
       r unless r.empty?
     end
   end


### PR DESCRIPTION
... lines in your yaml into multi line text