### PR TITLE
Nunchaku::ActiveRecord objects can now derive their engine

### DIFF
--- a/app/models/nunchaku/active_record.rb
+++ b/app/models/nunchaku/active_record.rb
@@ -6,6 +6,17 @@ module Nunchaku
     include Reflections
     include Composition
 
+    def self.engine
+      parents.detect do |parent|
+        begin
+          return "#{parent}::Engine".constantize
+        rescue NameError
+          # NOTE: +#safe_constantize+ isn't used here because it still throws an
+          #       exception when looking at +Object+
+        end
+      end
+    end
+
     def to_sym
       to_s.titleize.delete(' ').underscore.to_sym
     end


### PR DESCRIPTION
```
irb(main):001:0> Access::User.engine
=> Access::Engine
```