### PR TITLE
use length instead of size

### DIFF
--- a/app/controllers/concerns/nunchaku/paginated.rb
+++ b/app/controllers/concerns/nunchaku/paginated.rb
@@ -32,7 +32,7 @@ module Nunchaku::Paginated
   end
 
   def sweet_ux_count
-    cc = collection.size
+    cc = collection.length
     cc <= show_ahead_count ? cc : per_page
   end
 


### PR DESCRIPTION
collection.size can return a hash in some scenario.