### PR TITLE
Update rails, jquery-rails versions to pick up security fixes

### DIFF
--- a/nunchaku.gemspec
+++ b/nunchaku.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails', '~> 4.2.0' # Locked to prevent jquery.ui.all not found errors
   s.add_dependency 'kaminari'
-  s.add_dependency 'rails', '~> 4.1.0'
+  s.add_dependency 'rails', '~> 4.1.11'
   s.add_dependency 'ransack'
   s.add_dependency 'responders'
   s.add_dependency 'sass-rails', '~> 4.0.0'


### PR DESCRIPTION
See http://weblog.rubyonrails.org/2015/6/16/Rails-3-2-22-4-1-11-and-4-2-2-have-been-released-and-more/